### PR TITLE
Fix workflow badge in README

### DIFF
--- a/Example.tsx
+++ b/Example.tsx
@@ -4,8 +4,8 @@ import { useKeyboard } from '@react-native-community/hooks';
 import CodeEditor, { CodeEditorSyntaxStyles } from './src';
 
 const Example = (): JSX.Element => {
-    const keyboard = useKeyboard();
     const insets = useSafeAreaInsets();
+    const keyboard = useKeyboard();
 
     return (
         <SafeAreaView>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## React Native Code Editor
 
-[![npm-version](https://img.shields.io/npm/v/@rivascva/react-native-code-editor)](https://www.npmjs.com/package/@rivascva/react-native-code-editor) [![gh-actions-status](https://github.com/RivasCVA/react-native-code-editor/actions/workflows/workflow.yml/badge.svg)](https://github.com/RivasCVA/react-native-code-editor/actions/workflows/workflow.yml) [![license](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/RivasCVA/react-native-code-editor/blob/v1.0.3/LICENSE)
+[![npm-version](https://img.shields.io/npm/v/@rivascva/react-native-code-editor)](https://www.npmjs.com/package/@rivascva/react-native-code-editor) [![gh-actions-status](https://github.com/RivasCVA/react-native-code-editor/actions/workflows/lint-workflow.yml/badge.svg)](https://github.com/RivasCVA/react-native-code-editor/actions/workflows/lint-workflow.yml) [![license](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/RivasCVA/react-native-code-editor/blob/v1.0.3/LICENSE)
 
 A code editor with syntax highlighting built for React Native applications. The component is built on top of [React Syntax Highlighter](https://github.com/react-syntax-highlighter/react-syntax-highlighter). You can use it as a code editor or to display code snippets.
 


### PR DESCRIPTION
Fixed the workflow badge in the `README.md` to display the `Lint Workflow`.

