### PR TITLE
Android cursor alignment fix (Doesn't break iOS)

### DIFF
--- a/src/CodeEditor.tsx
+++ b/src/CodeEditor.tsx
@@ -293,5 +293,6 @@ const styles = StyleSheet.create({
         right: 0,
         bottom: 0,
         left: 0,
+        textAlignVertical: 'top',
     },
 });


### PR DESCRIPTION
Similar to #5 but doesn't break iOS